### PR TITLE
Replace io.utf8() with premake.utf8()

### DIFF
--- a/codelite_project.lua
+++ b/codelite_project.lua
@@ -432,7 +432,7 @@
 -- Project: Generate the CodeLite project file.
 --
 	function m.generate(prj)
-		io.utf8()
+		p.utf8()
 
 		p.callArray(m.elements.project, prj)
 

--- a/codelite_workspace.lua
+++ b/codelite_workspace.lua
@@ -21,7 +21,7 @@
 -- Generate a CodeLite workspace
 --
 	function m.generate(sln)
-		io.utf8()
+		p.utf8()
 
 		--
 		-- Header


### PR DESCRIPTION
This requires premake-core pull request #171 to be merged first. Prevents the workspace UTF8 BOM from getting written to the console while unit testing
