### PR TITLE
Fix "name in use" errors from module preload script

### DIFF
--- a/codelite.lua
+++ b/codelite.lua
@@ -66,8 +66,6 @@
 		-- TODO..
 	end
 
-
-	include("_preload.lua")
 	include("codelite_workspace.lua")
 	include("codelite_project.lua")
 


### PR DESCRIPTION
The module preloaded now uses `loadfile()` rather than `include()` in order to report script errors. As a result, the `_preload.lua` file is no longer marked as included, so subsequent calls to `include("_preload.lua")` will result in duplicated symbols.
