### PR TITLE
fixed debugdir not being used.

### DIFF
--- a/codelite_project.lua
+++ b/codelite_project.lua
@@ -258,7 +258,7 @@
 		local cmdargs    = iif(isExe, table.concat(cfg.debugargs, " "), "") -- TODO: should this be debugargs instead?
 		local useseparatedebugargs = "no"
 		local debugargs  = ""
-		local workingdir = iif(isExe, targetpath, "")
+		local workingdir = iif(isExe, project.getrelative(prj, cfg.debugdir), "")
 		local pauseexec  = iif(prj.kind == "ConsoleApp", "yes", "no")
 		local isguiprogram = iif(prj.kind == "WindowedApp", "yes", "no")
 		local isenabled  = iif(cfg.flags.ExcludeFromBuild, "no", "yes")


### PR DESCRIPTION
Made working directory grabbing the path specified in the debugdir variable.
Path for projects could not be found when opening Codelite due to path.translate(). I removed it and now works, at least on Linux. Would be nice if somebody could test it on other OSs.
