### PR TITLE
Fix unit test to match current behavior

### DIFF
--- a/tests/test_codelite_config.lua
+++ b/tests/test_codelite_config.lua
@@ -134,7 +134,7 @@
 		prepare()
 		codelite.project.general(cfg)
 		test.capture [[
-      <General OutputFile="bin/Debug/MyProject.exe" IntermediateDirectory="obj/Debug" Command="bin/Debug/MyProject.exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="bin/Debug" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <General OutputFile="bin/Debug/MyProject.exe" IntermediateDirectory="obj/Debug" Command="bin/Debug/MyProject.exe" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
 		]]
 	end
 


### PR DESCRIPTION
I _think_ this unit test has fallen out of date with the latest code. debugdir() is not set for the test, so the working directory should be the same as the project directory, so the attribute should be set to an empty string.

I need this test to pass before I can update remake-core master to use the latest version of this module.
