### PR TITLE
Fix tests to match premake/premake-core#474 behaviour

### DIFF
--- a/tests/test_codelite_config.lua
+++ b/tests/test_codelite_config.lua
@@ -44,7 +44,7 @@
 		prepare()
 		codelite.project.compiler(cfg)
 		test.capture [[
-      <Compiler Options="-g;-Og;-fPIC;-fno-exceptions;-fno-stack-protector;-std=c++11;-fno-rtti;-opt1;-opt2" C_Options="-g;-Og;-fPIC;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
+      <Compiler Options="-g;-O0;-fPIC;-fno-exceptions;-fno-stack-protector;-std=c++11;-fno-rtti;-opt1;-opt2" C_Options="-g;-O0;-fPIC;-opt1;-opt2" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" UseDifferentPCHFlags="no" PCHFlags="">
       </Compiler>
 		]]
 	end


### PR DESCRIPTION
@aleksijuvani I reopened this PR since it caused unit-tests to fail. I realised it was pending a PR to premake-core?

I'm not actually sure in which case codelite can produce this output...?
The project and the test assumes GCC is the compiler. To make codelite support clang this way, it would need to have support for `toolset` added properly no?
