### PR TITLE
Adjust paths to projects to use forward slashes

### DIFF
--- a/tests/test_codelite_workspace.lua
+++ b/tests/test_codelite_workspace.lua
@@ -98,7 +98,7 @@
 		test.capture([[
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
-  <Project Name="MyProject" Path="]] .. path.translate("MyProject/MyProject.project") .. [["/>
+  <Project Name="MyProject" Path="MyProject/MyProject.project"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="Debug"/>
@@ -117,7 +117,7 @@
 		test.capture([[
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeLite_Workspace Name="MyWorkspace" Database="" SWTLW="No">
-  <Project Name="MyProject" Path="]] .. path.translate("../MyProject/MyProject.project") .. [["/>
+  <Project Name="MyProject" Path="../MyProject/MyProject.project"/>
   <BuildMatrix>
     <WorkspaceConfiguration Name="Debug" Selected="yes">
       <Project Name="MyProject" ConfigName="Debug"/>


### PR DESCRIPTION
These two tests were failing in my Windows dev environment. I download the latest versions of CodeLite for both Mac and Windows and manually created new workspaces and C++ projects in both environments. In both cases, CodeLite used forward slashes in the workspace.

This changes the tests to always use forward slashes, which then passes in my Windows environment without any other changes to the code.
